### PR TITLE
removed charm tracing suffix

### DIFF
--- a/coordinator/tests/integration/helpers.py
+++ b/coordinator/tests/integration/helpers.py
@@ -37,6 +37,8 @@ WORKER_APP = "tempo-worker"
 TEMPO_APP = "tempo"
 SSC_APP = "ssc"
 TRAEFIK_APP = "trfk"
+# default worker charm channel when running in CI or without the WORKER_CHARM_PATH envvar set.
+WORKER_CHARM_CHANNEL = "2/edge"
 
 ALL_ROLES = [role.value for role in TempoRole.all_nonmeta()]
 ALL_WORKERS = [f"{WORKER_APP}-" + role for role in ALL_ROLES]
@@ -127,7 +129,7 @@ def tempo_worker_charm_and_channel_and_resources():
             None,
             get_resources(worker_charm_path.parent),
         )
-    return "tempo-worker-k8s", "edge", None
+    return "tempo-worker-k8s", WORKER_CHARM_CHANNEL, None
 
 
 def get_resources(path: Union[str, Path]):

--- a/coordinator/tests/integration/test_self_tracing.py
+++ b/coordinator/tests/integration/test_self_tracing.py
@@ -21,11 +21,6 @@ APP_REMOTE_WORKER_NAME = "tempo-remote-worker"
 APP_REMOTE_S3 = "tempo-remote-s3"
 
 
-WORKER_CHARM_TRACING_SUFFIX = "-charm"
-# FIXME: remove this in the next PR
-#  (as the change to the worker charm will be released)
-
-
 @pytest.mark.setup
 def test_build_and_deploy(juju: Juju):
     # deploy cluster
@@ -42,7 +37,7 @@ def test_verify_self_traces_collected(juju: Juju):
 
     for svc in (
         TEMPO_APP, # coordinator charm traces
-        WORKER_APP+WORKER_CHARM_TRACING_SUFFIX,  # worker charm traces
+        WORKER_APP,  # worker charm traces
         "tempo-scalable-single-binary", # worker's workload traces
     ):
         assert svc in services
@@ -73,9 +68,9 @@ def test_verify_self_traces_sent_to_remote(juju: Juju):
     services = get_ingested_traces_service_names(get_app_ip_address(juju, APP_REMOTE_NAME), tls=False)
     for svc in (
         TEMPO_APP, # coordinator charm traces
-        WORKER_APP+WORKER_CHARM_TRACING_SUFFIX,  # worker charm traces
+        WORKER_APP,  # worker charm traces
         APP_REMOTE_NAME, # remote coordinator charm traces
-        APP_REMOTE_WORKER_NAME+WORKER_CHARM_TRACING_SUFFIX,  # remote worker charm traces
+        APP_REMOTE_WORKER_NAME,  # remote worker charm traces
     ):
         assert svc in services
 


### PR DESCRIPTION
Now we have upgraded worker and coordinator the charm tracing service suffix `-charm` should no longer be there