### PR TITLE
fix: libpatch static check in coordinator

### DIFF
--- a/coordinator/tox.ini
+++ b/coordinator/tox.ini
@@ -78,4 +78,4 @@ allowlist_externals =
   /usr/bin/env
 commands =
     uv run {[vars]uv_flags} --all-extras pyright {[vars]src_path} {[vars]lib_path}
-    /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do if git ls-tree -r HEAD --name-only | grep -q "^$m$"; then  if ! git diff main $m | grep -q "+LIBPATCH\|+LIBAPI"; then echo "You forgot to bump the version on $m!"; exit 1; fi; fi; done'
+    /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path} | sed -E 's@^coordinator/@@g'); do if git ls-tree -r HEAD --name-only | grep -q "^$m$"; then  if ! git diff main $m | grep -q "+LIBPATCH\|+LIBAPI"; then echo "You forgot to bump the version on $m!"; exit 1; fi; fi; done'


### PR DESCRIPTION
## Issue
Currently, `tox -e static` fails to detect library changes and the subsequent need to update `LIBPATCH`. 

This happens because `git diff main --name-only {[vars]lib_path}`, which we use to get the list of libraries (`.py`) owned by the charm, now includes the `coordinator/` prefix. However, the `git ls-tree -r HEAD --name-only` command gives a path based on the current working directory; if called from the `coordinator/` folder (like it's done currently in CI), it will produce paths starting with `lib/`, causing the `grep` to fail.


## Solution
Strip the leading `coordinator/` from the list of libraries owned by the charm, so that the following `grep` works in any working directory.
