### PR TITLE
chore: split itest into one file per matrix cell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ requirements*.txt
 consolidated_rules/
 /coordinator/tests/integration/tester-grpc/lib/
 /coordinator/tests/integration/tester/lib/
+**/.logs/

--- a/tests/integration/assertions.py
+++ b/tests/integration/assertions.py
@@ -1,0 +1,21 @@
+from tests.integration.conftest import ALL_WORKERS, WORKER_APP, TEMPO_APP
+from tests.integration.helpers import get_unit_ip_address
+
+from jubilant import Juju
+import requests
+
+
+@retry(stop=stop_after_delay(2000), wait=wait_fixed(10))  # noqa: F821
+def assert_charm_traces_ingested(deployment:Juju, tls:bool, distributed:bool):
+    """Verify charm tracing for all tempo components."""
+    # get tempo's IP
+    tempo_ip = get_unit_ip_address(deployment, TEMPO_APP, 0)
+    # query the tempo HTTP API for all juju_applications currently sending traces
+    application_tags = requests.get(
+        f"http{'s' if tls else ''}://{tempo_ip}:3200/api/search/tag/juju_application/values",
+        verify=False,
+    ).json()
+
+    # verify tempo coordinator and all workers are in there
+    apps = {TEMPO_APP, *(ALL_WORKERS if distributed else (WORKER_APP,))}
+    assert apps.issubset(application_tags["tagValues"]), application_tags["tagValues"]

--- a/tests/integration/test_self_monitoring_distributed.py
+++ b/tests/integration/test_self_monitoring_distributed.py
@@ -7,10 +7,10 @@ from utils import assert_charm_traces_ingested
 
 @pytest.fixture
 def deployment(juju, do_setup, do_teardown):
-    # set up a monolithic deployment with no tls and no ingress
+    # set up a monolithic deployment with tls and no ingress
     with deployment_factory(
         tls=False,
-        distributed=False,
+        distributed=True,
         juju=juju,
         do_setup=do_setup,
         do_teardown=do_teardown

--- a/tests/integration/test_self_monitoring_distributed_tls.py
+++ b/tests/integration/test_self_monitoring_distributed_tls.py
@@ -7,10 +7,10 @@ from utils import assert_charm_traces_ingested
 
 @pytest.fixture
 def deployment(juju, do_setup, do_teardown):
-    # set up a monolithic deployment with no tls and no ingress
+    # set up a distributed deployment with tls and no ingress
     with deployment_factory(
-        tls=False,
-        distributed=False,
+        tls=True,
+        distributed=True,
         juju=juju,
         do_setup=do_setup,
         do_teardown=do_teardown

--- a/tests/integration/test_self_monitoring_tls.py
+++ b/tests/integration/test_self_monitoring_tls.py
@@ -7,9 +7,9 @@ from utils import assert_charm_traces_ingested
 
 @pytest.fixture
 def deployment(juju, do_setup, do_teardown):
-    # set up a monolithic deployment with no tls and no ingress
+    # set up a monolithic deployment with tls and no ingress
     with deployment_factory(
-        tls=False,
+        tls=True,
         distributed=False,
         juju=juju,
         do_setup=do_setup,


### PR DESCRIPTION
We previously cowboy-experimentally merged a pytest-option-based way to run the itest suite into one of multiple possible modes/configurations: with and without:
 - TLS
 - distributed mode
 - (soon: ingress)
 
 Turns out it's hard to convince folks we should update our CIs to support this way of declaring tests, so here I'm rolling that partially back to use separate test files, one per cell in this matrix. 
 Do note that once we add ingress, we'll have to *2 the number of test files containing 99% of the same code. We'll curse that bridge when we get to it.
 
 