### PR TITLE
feat: Grafana datasource deduplication on ingress

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -180,6 +180,11 @@ class TempoCoordinatorCharm(CharmBase):
             source_type="tempo",
             source_url=self._external_http_server_url,
             extra_fields=self._build_grafana_source_extra_fields(),
+            refresh_event=[
+                self.coordinator.cluster.on.changed,
+                self.on[self.coordinator._certificates.relationship_name].relation_changed,
+            ],
+            is_ingress_per_app=self.ingress.is_ready(),
         )
 
         # wokeignore:rule=blackbox

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -180,11 +180,7 @@ class TempoCoordinatorCharm(CharmBase):
             source_type="tempo",
             source_url=self._external_http_server_url,
             extra_fields=self._build_grafana_source_extra_fields(),
-            refresh_event=[
-                self.coordinator.cluster.on.changed,
-                self.on[self.coordinator._certificates.relationship_name].relation_changed,
-            ],
-            is_ingress_per_app=self.ingress.is_ready(),
+            is_ingress_per_app=self._is_ingress_ready,
         )
 
         # wokeignore:rule=blackbox
@@ -252,6 +248,15 @@ class TempoCoordinatorCharm(CharmBase):
         )
 
     @property
+    def _is_ingress_ready(self) -> bool:
+        "Return True if an ingress is configured and ready, otherwise False."
+        return bool(
+            self.ingress.is_ready()
+            and self.ingress.scheme
+            and self.ingress.external_host
+        )
+
+    @property
     def _external_http_server_url(self) -> str:
         """External url of the http(s) server."""
         return f"{self._most_external_url}:{Tempo.tempo_http_server_port}"
@@ -259,11 +264,7 @@ class TempoCoordinatorCharm(CharmBase):
     @property
     def _external_url(self) -> Optional[str]:
         """Return the external URL if the ingress is configured and ready, otherwise None."""
-        if (
-            self.ingress.is_ready()
-            and self.ingress.scheme
-            and self.ingress.external_host
-        ):
+        if self._is_ingress_ready:
             ingress_url = f"{self.ingress.scheme}://{self.ingress.external_host}"
             logger.debug("This unit's ingress URL: %s", ingress_url)
             return ingress_url
@@ -583,15 +584,9 @@ class TempoCoordinatorCharm(CharmBase):
         if ingress is used, return endpoint provided by the ingress instead.
         """
         protocol_type = receiver_protocol_to_transport_protocol.get(protocol)
-        # ingress.is_ready returns True even when traefik hasn't sent any data yet
-        has_ingress = (
-            self.ingress.is_ready()
-            and self.ingress.external_host
-            and self.ingress.scheme
-        )
         receiver_port = self.tempo.receiver_ports[protocol]
 
-        if has_ingress:
+        if self._is_ingress_ready:
             url = (
                 self.ingress.external_host
                 if protocol_type == TransportProtocolType.grpc


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Only provide one Grafana data source (from the leader) when ingressed, otherwise each unit provides one.

## Solution
<!-- A summary of the solution addressing the above issue -->
Tandem PR:
- https://github.com/canonical/grafana-k8s-operator/pull/427

Related:
- https://github.com/canonical/mimir-coordinator-k8s-operator/pull/161
- https://github.com/canonical/loki-coordinator-k8s-operator/pull/77

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- https://github.com/canonical/grafana-k8s-operator/pull/427#issuecomment-3090584719

I recommend adding a check like [this itest in Loki and Mimir](https://github.com/canonical/loki-coordinator-k8s-operator/pull/77/files#diff-beb059a2a961b3fd25964af094abab78d8ce11c340055470b21f886eaa2e67f9L133) to ensure the datasources (according to Grafana's API) are updated in the datastore.