### PR TITLE
chore: add shared unit tox env for coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ consolidated_rules/
 /coordinator/tests/integration/tester-grpc/lib/
 /coordinator/tests/integration/tester/lib/
 **/.logs/
+cover/

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,16 @@ description = Update uv.lock with the latest deps
 commands =
   uv lock --upgrade --no-cache
 
+[testenv:unit]
+description = Run the combined coordinator/worker unittests
+allowlist_externals =
+  tox
+  coverage
+commands =
+  tox -c ./worker/tox.ini -vve unit {posargs}
+  tox -c ./coordinator/tox.ini -vve unit {posargs}
+  coverage combine ./worker/.coverage ./coordinator/.coverage
+
 [testenv:integration]
 description = Run integration tests
 commands =


### PR DESCRIPTION
The [tics workflow has been failing since the monorepo migration](https://github.com/canonical/tempo-operators/actions/runs/16711098265/job/47296175929)

This should fix it.