### PR TITLE
feat: link traces to logs

### DIFF
--- a/coordinator/scripts/deploy_minio.py
+++ b/coordinator/scripts/deploy_minio.py
@@ -166,7 +166,7 @@ def deploy(
         print(f"deploying s3 as {s3_app_name!r}")
         _run(f"juju deploy s3-integrator --channel edge --trust {s3_app_name}")
     else:
-        print(f"found existing s3 deployment at {minio_app_name}")
+        print(f"found existing s3 deployment at {s3_app_name}")
 
 
     print(f"waiting for minio ({minio_app_name}) to report active...", end="")

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -53,6 +53,7 @@ from telemetry_correlation import TelemetryCorrelation
 from tempo import Tempo
 from tempo_config import TEMPO_ROLES_CONFIG, TempoRole
 from nginx_config import upstreams, server_ports_to_locations
+from cosl.reconciler import all_events, observe_events
 
 logger = logging.getLogger(__name__)
 PEERS_RELATION_ENDPOINT_NAME = "peers"
@@ -212,13 +213,13 @@ class TempoCoordinatorCharm(CharmBase):
             # logging is handled by the Coordinator object
             return
 
-        # do this regardless of what event we are processing
-        self._reconcile()
-
         # actions
         self.framework.observe(
             self.on.list_receivers_action, self._on_list_receivers_action
         )
+
+        # do this regardless of what event we are processing
+        observe_events(self, all_events, self._reconcile)
 
     ######################
     # UTILITY PROPERTIES #
@@ -773,15 +774,15 @@ class TempoCoordinatorCharm(CharmBase):
 
         svc_graph_config = self._build_service_graph_config()
 
-        cross_telemetry_config = self._build_traces_to_logs_config()
+        traces_to_logs_config = self._build_traces_to_logs_config()
 
-        if not svc_graph_config and not cross_telemetry_config:
+        if not svc_graph_config and not traces_to_logs_config:
             return None
 
         return {
             "httpMethod": "GET",
             **svc_graph_config,
-            **cross_telemetry_config,
+            **traces_to_logs_config,
         }
 
     @property

--- a/coordinator/src/telemetry_correlation.py
+++ b/coordinator/src/telemetry_correlation.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utilities for working with telemetry correlation."""
+
+import json
+import logging
+from typing import Dict, Optional
+
+import ops
+
+from coordinated_workers.coordinator import Coordinator
+from cosl.interfaces.datasource_exchange import (
+    DSExchangeAppData,
+    GrafanaDatasource,
+)
+from cosl.interfaces.utils import DataValidationError
+
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryCorrelation:
+    """Logic to work with datasource-exchange."""
+
+    def __init__(self, charm: ops.CharmBase, coordinator: Coordinator):
+        self._charm = charm
+        self._coordinator = coordinator
+
+    def find_datasource(
+        self, endpoint: str, datasource_type: str
+    ) -> Optional[GrafanaDatasource]:
+        """Find a datasource we obtained through datasource-exchange.
+
+        Such that: its remote is the same as the remote we have on this endpoint.
+        """
+        dsx_relations = {
+            relation.app.name: relation
+            for relation in self._coordinator.datasource_exchange._relations
+        }
+
+        remote_apps_on_endpoint = {
+            relation.app.name
+            for relation in self._charm.model.relations[endpoint]
+            if relation.app and relation.data
+        }
+
+        # the list of datasource exchange relations whose remote we're also remote writing to.
+        remote_write_dsx_relations = [
+            dsx_relations[app_name]
+            for app_name in set(dsx_relations).intersection(remote_apps_on_endpoint)
+        ]
+
+        # grafana UIDs that are connected to this Tempo.
+        grafana_uids = set(self._get_grafana_source_uids())
+
+        remote_write_dsx_databags = []
+        for relation in remote_write_dsx_relations:
+            try:
+                datasource = DSExchangeAppData.load(relation.data[relation.app])
+                remote_write_dsx_databags.append(datasource)
+            except DataValidationError:
+                # load() already logs
+                continue
+
+        # filter the remote_write_dsx_databags with those that are connected to the same grafana instances Tempo is connected to.
+        matching_datasources = [
+            datasource
+            for databag in remote_write_dsx_databags
+            for datasource in databag.datasources
+            if datasource.grafana_uid in grafana_uids
+            and datasource.type == datasource_type
+        ]
+
+        if not matching_datasources:
+            # take good care of logging exactly why this happening, as the logic is quite complex and debugging this will be hell
+            msg = "service graph disabled."
+            missing_rels = []
+            if not remote_apps_on_endpoint:
+                missing_rels.append(endpoint)
+            if not grafana_uids:
+                missing_rels.append("grafana-source")
+            if not dsx_relations:
+                missing_rels.append("receive-datasource")
+
+            if missing_rels:
+                msg += f" Missing relations: {missing_rels}."
+
+            if not remote_write_dsx_relations:
+                msg += " There are no datasource_exchange relations with a Prometheus/Mimir that we're also remote writing to."
+            else:
+                msg += " There are no datasource_exchange relations to a Prometheus/Mimir that are datasources to the same grafana instances Tempo is connected to."
+
+            logger.info(msg)
+            return None
+
+        if len(matching_datasources) > 1:
+            logger.info(
+                "there are multiple datasources that could be used to create the service graph. We assume that all are equivalent."
+            )
+
+        # At this point, we can assume any datasource is a valid datasource to use for service graphs.
+        return matching_datasources[0]
+
+    def _get_grafana_source_uids(self) -> Dict[str, Dict[str, str]]:
+        """Helper method to retrieve the databags of any grafana-source relations.
+
+        Duplicate implementation of GrafanaSourceProvider.get_source_uids() to use in the
+        situation where we want to access relation data when the GrafanaSourceProvider object
+        is not yet initialised.
+        """
+        uids = {}
+        for rel in self._charm.model.relations.get("grafana-source", []):
+            if not rel:
+                continue
+            app_databag = rel.data[rel.app]
+            grafana_uid = app_databag.get("grafana_uid")
+            if not grafana_uid:
+                logger.warning(
+                    "remote end is using an old grafana_datasource interface: "
+                    "`grafana_uid` field not found."
+                )
+                continue
+
+            uids[grafana_uid] = json.loads(app_databag.get("datasource_uids", "{}"))
+        return uids

--- a/coordinator/tests/scenario/test_datasources.py
+++ b/coordinator/tests/scenario/test_datasources.py
@@ -310,3 +310,90 @@ def test_no_service_graph_with_wrong_dsx(
         service_graph_config = charm._build_service_graph_config()
         # THEN a service graph config will not be generated.
         assert not service_graph_config
+
+@patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
+def test_cross_telemetry_config_no_datasources(
+    workload_ready_mock,
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # WHEN there are no received datasources
+    relations = [
+        PeerRelation("peers", peers_data={1: {}, 2: {}}),
+        s3,
+        all_worker,
+    ]
+    state_in = State(
+        relations=relations,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+    with context(context.on.update_status(), state_in) as mgr:
+        mgr.run()
+        charm = mgr.charm
+        config = charm._build_cross_telemetry_config()
+        assert config == {}
+
+
+@patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
+def test_cross_telemetry_config_non_loki_datasources(
+    workload_ready_mock,
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # WHEN only non-loki datasources are present
+    relations = [
+        PeerRelation("peers", peers_data={1: {}, 2: {}}),
+        s3,
+        all_worker,
+        grafana_datasource_exchange_relation(
+            datasources=[{"type": "prometheus", "uid": "prom_1", "grafana_uid": "graf_1"}]
+        ),
+    ]
+    state_in = State(
+        relations=relations,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+    with context(context.on.update_status(), state_in) as mgr:
+        mgr.run()
+        charm = mgr.charm
+        config = charm._build_cross_telemetry_config()
+        assert config == {}
+
+
+@patch("charm.TempoCoordinatorCharm.is_workload_ready", return_value=True)
+def test_cross_telemetry_config_loki_datasource(
+    workload_ready_mock,
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # WHEN a single loki datasource is present
+    relations = [
+        PeerRelation("peers", peers_data={1: {}, 2: {}}),
+        s3,
+        all_worker,
+        grafana_datasource_exchange_relation(
+            datasources=[{"type": "loki", "uid": "loki_1", "grafana_uid": "graf_1"}]
+        ),
+    ]
+    state_in = State(
+        relations=relations,
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+    with context(context.on.update_status(), state_in) as mgr:
+        mgr.run()
+        charm = mgr.charm
+        config = charm._build_cross_telemetry_config()
+        assert "tracesToLogsV2" in config
+        assert config["tracesToLogsV2"]["datasourceUid"] == "loki_1"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The PR adds cross-telemetry configuration for traces-to-logs correlation in Grafana, specifically for Loki datasources. This is important for allowing  navigation from traces to logs in observability setups.

## Solution
<!-- A summary of the solution addressing the above issue -->
The added code inspects received datasources and, for a received Loki datasource, generates the appropriate `tracesToLogsV2` configuration block. The config includes the Loki datasource UID, tags for Juju topology, and a query filtering by the traceID.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. deploy and setup the charm  (with worker, s3 and all)
2. deploy Loki and Grafana, relate them through `grafana-source`
3. relate tempo to Loki through `datasource_exchange` and to Grafana through `grafana-source`, then inspect the generated config in the relation data. Or go to the datasource details through grafana UI
4. you should see the "Traces to Logs" section populated


## Upgrade Notes
N/A
