### PR TITLE
chore: Unpin s3-integrator revision

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -68,7 +68,7 @@ This is a Terraform module facilitating the deployment of Tempo solution, using 
 | <a name="input_s3_integrator_config"></a> [s3\_integrator\_config](#input\_s3\_integrator\_config) | Map of the s3-integrator configuration options | `map(string)` | `{}` | no |
 | <a name="input_s3_integrator_constraints"></a> [s3\_integrator\_constraints](#input\_s3\_integrator\_constraints) | String listing constraints for the s3-integrator application | `string` | `"arch=amd64"` | no |
 | <a name="input_s3_integrator_name"></a> [s3\_integrator\_name](#input\_s3\_integrator\_name) | Name of the s3-integrator app | `string` | `"tempo-s3-integrator"` | no |
-| <a name="input_s3_integrator_revision"></a> [s3\_integrator\_revision](#input\_s3\_integrator\_revision) | Revision number of the s3-integrator application | `number` | `157` | no |
+| <a name="input_s3_integrator_revision"></a> [s3\_integrator\_revision](#input\_s3\_integrator\_revision) | Revision number of the s3-integrator application | `number` | `null` | no |
 | <a name="input_s3_integrator_storage_directives"></a> [s3\_integrator\_storage\_directives](#input\_s3\_integrator\_storage\_directives) | Map of storage used by the s3-integrator application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
 | <a name="input_s3_integrator_units"></a> [s3\_integrator\_units](#input\_s3\_integrator\_units) | Number of S3 integrator units | `number` | `1` | no |
 | <a name="input_s3_secret_key"></a> [s3\_secret\_key](#input\_s3\_secret\_key) | S3 secret-key credential | `string` | n/a | yes |

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -197,7 +197,7 @@ variable "worker_revision" {
 variable "s3_integrator_revision" {
   description = "Revision number of the s3-integrator application"
   type        = number
-  default     = 157 # FIXME: https://github.com/canonical/observability/issues/342
+  default     = null
 }
 
 # -------------- # Storage directives --------------


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
As https://github.com/canonical/observability-stack/pull/118 was recently merged in observability-stack (and the PR removing tempo from there still haven't), apply unpinning of the s3-integrator revision in our terraform code too.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
https://github.com/canonical/observability-stack/pull/105

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed tempo, ... -->
