### PR TITLE
feat: Allow setting the coordinator application name in the Terraform config

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,6 +40,7 @@ resource "juju_application" "s3_integrator" {
 module "tempo_coordinator" {
   source = "git::https://github.com/canonical/tempo-operators//coordinator/terraform"
 
+  app_name           = var.coordinator_name
   channel            = var.channel
   config             = var.coordinator_config
   constraints        = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo,anti-pod.topology-key=kubernetes.io/hostname" : var.coordinator_constraints

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,6 +46,12 @@ variable "s3_endpoint" {
 
 # -------------- # App Names --------------
 
+variable "coordinator_name" {
+  description = "Name of the Tempo coordinator app"
+  type        = string
+  default     = "tempo"
+}
+
 variable "querier_name" {
   description = "Name of the Tempo querier app"
   type        = string


### PR DESCRIPTION
## Issue
Closes #227 


## Solution
Add a new `coordinator_name` variable to the primary Terraform configuration file that allows the user to override the application name for the Tempo coordinator. This variable still defaults to `tempo` to match existing behavior.


## Testing Instructions
Try deploying with Terraform, setting the `coordinator_name` variable to something other than `tempo`. The coordinator application should have a matching name.

Try deploying without setting the `coordinator_name` variable. The coordinator application should be deployed as "tempo"