### PR TITLE
chore: Update wokeignore not to scan vendored libraries

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,2 +1,13 @@
-lib/charms/blackbox_exporter_k8s
+**/lib/charms/blackbox_exporter_k8s
+**/lib/charms/catalogue_k8s
+**/lib/charms/data_platform_libs
+**/lib/charms/grafana_k8s
+**/lib/charms/istio_beacon_k8s
+**/lib/charms/istio_ingress_k8s
+**/lib/charms/loki_k8s
+**/lib/charms/observability_libs
+**/lib/charms/parca
+**/lib/charms/prometheus_k8s
+**/lib/charms/tls_certificates_interface
+**/lib/charms/traefik_k8s
 charmcraft.yaml


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
`.wokeignore` was allowing scanning vendored libraries.

## Solution
<!-- A summary of the solution addressing the above issue -->
Adjust the file to match moving the libraries to coordinator's repo after monorepo migration.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed tempo, ... -->
