### PR TITLE
feat(terraform): support monolithic deployment mode

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,5 @@
 resource "juju_secret" "tempo_s3_credentials_secret" {
+  count      = var.deploy_s3_integrator ? 1 : 0
   model_uuid = var.model_uuid
   name       = "tempo_s3_credentials"
   value = {
@@ -9,19 +10,21 @@ resource "juju_secret" "tempo_s3_credentials_secret" {
 }
 
 resource "juju_access_secret" "tempo_s3_secret_access" {
+  count      = var.deploy_s3_integrator ? 1 : 0
   model_uuid = var.model_uuid
   applications = [
-    juju_application.s3_integrator.name
+    juju_application.s3_integrator[0].name
   ]
-  secret_id = juju_secret.tempo_s3_credentials_secret.secret_id
+  secret_id = juju_secret.tempo_s3_credentials_secret[0].secret_id
 }
 
 # TODO: Replace s3_integrator resource to use its remote terraform module once available
 resource "juju_application" "s3_integrator" {
+  count = var.deploy_s3_integrator ? 1 : 0
   config = merge({
     endpoint    = var.s3_endpoint
     bucket      = var.s3_bucket
-    credentials = "secret:${juju_secret.tempo_s3_credentials_secret.secret_id}"
+    credentials = "secret:${juju_secret.tempo_s3_credentials_secret[0].secret_id}"
   }, var.s3_integrator_config)
   constraints        = var.s3_integrator_constraints
   model_uuid         = var.model_uuid
@@ -177,9 +180,10 @@ module "tempo_metrics_generator" {
 
 resource "juju_integration" "coordinator_to_s3_integrator" {
   model_uuid = var.model_uuid
+  count      = var.deploy_s3_integrator ? 1 : 0
 
   application {
-    name     = juju_application.s3_integrator.name
+    name     = juju_application.s3_integrator[0].name
     endpoint = "s3-credentials"
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,9 +50,25 @@ module "tempo_coordinator" {
   units              = var.coordinator_units
 }
 
+module "tempo_all" {
+  source     = "../worker/terraform"
+  depends_on = [module.tempo_coordinator]
+  count      = var.monolithic ? 1 : 0
+
+  app_name           = var.all_name
+  channel            = var.channel
+  config             = merge({ role-all = true }, var.all_config)
+  constraints        = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=${var.all_name},anti-pod.topology-key=kubernetes.io/hostname" : var.worker_constraints
+  model_uuid         = var.model_uuid
+  revision           = var.worker_revision
+  storage_directives = var.all_worker_storage_directives
+  units              = var.all_units
+}
+
 module "tempo_querier" {
   source     = "../worker/terraform"
   depends_on = [module.tempo_coordinator]
+  count      = var.monolithic ? 0 : 1
 
   app_name = var.querier_name
   channel  = var.channel
@@ -70,6 +86,7 @@ module "tempo_querier" {
 module "tempo_query_frontend" {
   source     = "../worker/terraform"
   depends_on = [module.tempo_coordinator]
+  count      = var.monolithic ? 0 : 1
 
   app_name    = var.query_frontend_name
   model_uuid  = var.model_uuid
@@ -87,6 +104,7 @@ module "tempo_query_frontend" {
 module "tempo_ingester" {
   source     = "../worker/terraform"
   depends_on = [module.tempo_coordinator]
+  count      = var.monolithic ? 0 : 1
 
   app_name    = var.ingester_name
   model_uuid  = var.model_uuid
@@ -104,6 +122,7 @@ module "tempo_ingester" {
 module "tempo_distributor" {
   source     = "../worker/terraform"
   depends_on = [module.tempo_coordinator]
+  count      = var.monolithic ? 0 : 1
 
   app_name    = var.distributor_name
   model_uuid  = var.model_uuid
@@ -121,6 +140,7 @@ module "tempo_distributor" {
 module "tempo_compactor" {
   source     = "../worker/terraform"
   depends_on = [module.tempo_coordinator]
+  count      = var.monolithic ? 0 : 1
 
   app_name    = var.compactor_name
   model_uuid  = var.model_uuid
@@ -138,6 +158,7 @@ module "tempo_compactor" {
 module "tempo_metrics_generator" {
   source     = "../worker/terraform"
   depends_on = [module.tempo_coordinator]
+  count      = var.monolithic ? 0 : 1
 
   app_name    = var.metrics_generator_name
   model_uuid  = var.model_uuid
@@ -170,6 +191,7 @@ resource "juju_integration" "coordinator_to_s3_integrator" {
 
 resource "juju_integration" "coordinator_to_querier" {
   model_uuid = var.model_uuid
+  count      = var.monolithic ? 0 : 1
 
   application {
     name     = module.tempo_coordinator.app_name
@@ -177,13 +199,14 @@ resource "juju_integration" "coordinator_to_querier" {
   }
 
   application {
-    name     = module.tempo_querier.app_name
+    name     = module.tempo_querier[0].app_name
     endpoint = "tempo-cluster"
   }
 }
 
 resource "juju_integration" "coordinator_to_query_frontend" {
   model_uuid = var.model_uuid
+  count      = var.monolithic ? 0 : 1
 
   application {
     name     = module.tempo_coordinator.app_name
@@ -191,13 +214,14 @@ resource "juju_integration" "coordinator_to_query_frontend" {
   }
 
   application {
-    name     = module.tempo_query_frontend.app_name
+    name     = module.tempo_query_frontend[0].app_name
     endpoint = "tempo-cluster"
   }
 }
 
 resource "juju_integration" "coordinator_to_ingester" {
   model_uuid = var.model_uuid
+  count      = var.monolithic ? 0 : 1
 
   application {
     name     = module.tempo_coordinator.app_name
@@ -205,13 +229,14 @@ resource "juju_integration" "coordinator_to_ingester" {
   }
 
   application {
-    name     = module.tempo_ingester.app_name
+    name     = module.tempo_ingester[0].app_name
     endpoint = "tempo-cluster"
   }
 }
 
 resource "juju_integration" "coordinator_to_distributor" {
   model_uuid = var.model_uuid
+  count      = var.monolithic ? 0 : 1
 
   application {
     name     = module.tempo_coordinator.app_name
@@ -219,13 +244,14 @@ resource "juju_integration" "coordinator_to_distributor" {
   }
 
   application {
-    name     = module.tempo_distributor.app_name
+    name     = module.tempo_distributor[0].app_name
     endpoint = "tempo-cluster"
   }
 }
 
 resource "juju_integration" "coordinator_to_compactor" {
   model_uuid = var.model_uuid
+  count      = var.monolithic ? 0 : 1
 
   application {
     name     = module.tempo_coordinator.app_name
@@ -233,13 +259,14 @@ resource "juju_integration" "coordinator_to_compactor" {
   }
 
   application {
-    name     = module.tempo_compactor.app_name
+    name     = module.tempo_compactor[0].app_name
     endpoint = "tempo-cluster"
   }
 }
 
 resource "juju_integration" "coordinator_to_metrics_generator" {
   model_uuid = var.model_uuid
+  count      = var.monolithic ? 0 : 1
 
   application {
     name     = module.tempo_coordinator.app_name
@@ -247,7 +274,22 @@ resource "juju_integration" "coordinator_to_metrics_generator" {
   }
 
   application {
-    name     = module.tempo_metrics_generator.app_name
+    name     = module.tempo_metrics_generator[0].app_name
+    endpoint = "tempo-cluster"
+  }
+}
+
+resource "juju_integration" "coordinator_to_all" {
+  model_uuid = var.model_uuid
+  count      = var.monolithic ? 1 : 0
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "tempo-cluster"
+  }
+
+  application {
+    name     = module.tempo_all[0].app_name
     endpoint = "tempo-cluster"
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,12 +3,13 @@ output "app_names" {
     {
       tempo_s3_integrator     = juju_application.s3_integrator.name,
       tempo_coordinator       = module.tempo_coordinator.app_name,
-      tempo_querier           = module.tempo_querier.app_name,
-      tempo_query_frontend    = module.tempo_query_frontend.app_name,
-      tempo_ingester          = module.tempo_ingester.app_name,
-      tempo_distributor       = module.tempo_distributor.app_name,
-      tempo_compactor         = module.tempo_compactor.app_name,
-      tempo_metrics_generator = module.tempo_metrics_generator.app_name,
+      tempo_all               = var.monolithic ? module.tempo_all[0].app_name : null,
+      tempo_querier           = var.monolithic ? null : module.tempo_querier[0].app_name,
+      tempo_query_frontend    = var.monolithic ? null : module.tempo_query_frontend[0].app_name,
+      tempo_ingester          = var.monolithic ? null : module.tempo_ingester[0].app_name,
+      tempo_distributor       = var.monolithic ? null : module.tempo_distributor[0].app_name,
+      tempo_compactor         = var.monolithic ? null : module.tempo_compactor[0].app_name,
+      tempo_metrics_generator = var.monolithic ? null : module.tempo_metrics_generator[0].app_name,
     }
   )
   description = "All application names which make up this product module"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,7 +1,7 @@
 output "app_names" {
   value = merge(
     {
-      tempo_s3_integrator     = juju_application.s3_integrator.name,
+      tempo_s3_integrator     = var.deploy_s3_integrator ? juju_application.s3_integrator[0].name : null,
       tempo_coordinator       = module.tempo_coordinator.app_name,
       tempo_all               = var.monolithic ? module.tempo_all[0].app_name : null,
       tempo_querier           = var.monolithic ? null : module.tempo_querier[0].app_name,

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,6 +19,12 @@ variable "anti_affinity" {
   default     = true
 }
 
+variable "monolithic" {
+  description = "Deploy a single worker with all roles instead of separate role workers"
+  type        = bool
+  default     = false
+}
+
 # -------------- # S3 object storage --------------
 
 variable "s3_integrator_channel" {
@@ -55,6 +61,12 @@ variable "coordinator_name" {
   description = "Name of the Tempo coordinator app"
   type        = string
   default     = "tempo"
+}
+
+variable "all_name" {
+  description = "Name of the Tempo all-in-one worker app"
+  type        = string
+  default     = "tempo-worker"
 }
 
 variable "querier_name" {
@@ -103,6 +115,12 @@ variable "s3_integrator_name" {
 
 variable "coordinator_config" {
   description = "Map of the coordinator configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "all_config" {
+  description = "Map of the all-in-one worker configuration options"
   type        = map(string)
   default     = {}
 }
@@ -219,6 +237,12 @@ variable "coordinator_storage_directives" {
   default     = {}
 }
 
+variable "all_worker_storage_directives" {
+  description = "Map of storage used by the all-in-one worker application, which defaults to 1 GB, allocated by Juju"
+  type        = map(string)
+  default     = {}
+}
+
 variable "compactor_worker_storage_directives" {
   description = "Map of storage used by the compactor worker application, which defaults to 1 GB, allocated by Juju"
   type        = map(string)
@@ -262,6 +286,16 @@ variable "s3_integrator_storage_directives" {
 }
 
 # -------------- # Units Per App --------------
+
+variable "all_units" {
+  description = "Number of Tempo worker units with all roles"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.all_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
 
 variable "compactor_units" {
   description = "Number of Tempo worker units with compactor role"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,6 +25,12 @@ variable "monolithic" {
   default     = false
 }
 
+variable "deploy_s3_integrator" {
+  description = "Deploy an s3-integrator to configure object storage. Set to false when using a charm that provides the s3 interface directly (e.g. seaweedfs-k8s)."
+  type        = bool
+  default     = true
+}
+
 # -------------- # S3 object storage --------------
 
 variable "s3_integrator_channel" {
@@ -40,19 +46,22 @@ variable "s3_bucket" {
 }
 
 variable "s3_access_key" {
-  description = "S3 access-key credential"
+  description = "S3 access-key credential. Required when deploy_s3_integrator is true."
   type        = string
+  default     = null
 }
 
 variable "s3_secret_key" {
-  description = "S3 secret-key credential"
+  description = "S3 secret-key credential. Required when deploy_s3_integrator is true."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "s3_endpoint" {
-  description = "S3 endpoint"
+  description = "S3 endpoint. Required when deploy_s3_integrator is true."
   type        = string
+  default     = null
 }
 
 # -------------- # App Names --------------


### PR DESCRIPTION
Adds a `monolithic` variable to the terraform module. When set to `true`, a single
role-all worker is deployed instead of the 6 separate role workers (querier,
query-frontend, ingester, distributor, compactor, metrics-generator).

This is needed by canonical/observability-stack#193 to support lightweight COS
deployment flavors for integration testing.

When `monolithic = false` (default), behavior is unchanged.