### PR TITLE
feat: TF service mesh outputs

### DIFF
--- a/coordinator/terraform/outputs.tf
+++ b/coordinator/terraform/outputs.tf
@@ -7,6 +7,7 @@ output "provides" {
     grafana_dashboard = "grafana-dashboard",
     grafana_source    = "grafana-source",
     metrics_endpoint  = "metrics-endpoint",
+    provide_cmr_mesh  = "provide-cmr-mesh",
     tempo_cluster     = "tempo-cluster",
     tracing           = "tracing",
   }
@@ -21,7 +22,9 @@ output "requires" {
     self_charm_tracing    = "self-charm-tracing",
     self_workload_tracing = "self-workload-tracing",
     send_remote_write     = "send-remote-write",
-    receive_datasource    = "receive-datasource"
+    receive_datasource    = "receive-datasource",
+    require_cmr_mesh      = "require-cmr-mesh",
+    service_mesh          = "service-mesh",
     catalogue             = "catalogue",
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -20,6 +20,7 @@ output "provides" {
     grafana_dashboard = "grafana-dashboard",
     grafana_source    = "grafana-source",
     metrics_endpoint  = "metrics-endpoint",
+    provide_cmr_mesh  = "provide-cmr-mesh",
     tracing           = "tracing",
   }
   description = "All Juju integration endpoints where the charm is the provider"
@@ -33,6 +34,8 @@ output "requires" {
     send-remote-write  = "send-remote-write",
     receive_datasource = "receive-datasource"
     catalogue          = "catalogue",
+    require_cmr_mesh   = "require-cmr-mesh",
+    service_mesh       = "service-mesh",
   }
   description = "All Juju integration endpoints where the charm is the requirer"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -20,7 +20,7 @@ output "provides" {
     grafana_dashboard = "grafana-dashboard",
     grafana_source    = "grafana-source",
     metrics_endpoint  = "metrics-endpoint",
-    provide_cmr_mesh  = "provide-cmr-mesh",
+    provide_cmr_mesh  = module.mimir_coordinator.provides.provide_cmr_mesh,
     tracing           = "tracing",
   }
   description = "All Juju integration endpoints where the charm is the provider"
@@ -34,8 +34,8 @@ output "requires" {
     send-remote-write  = "send-remote-write",
     receive_datasource = "receive-datasource"
     catalogue          = "catalogue",
-    require_cmr_mesh   = "require-cmr-mesh",
-    service_mesh       = "service-mesh",
+    require_cmr_mesh   = module.mimir_coordinator.provides.require_cmr_mesh,
+    service_mesh       = module.mimir_coordinator.provides.service_mesh,
   }
   description = "All Juju integration endpoints where the charm is the requirer"
 }


### PR DESCRIPTION
Add TF outputs for service mesh integrations so the products can use it

> [!WARNING]
> We should reference the charm module requires and provides everywhere, instead of hardcoding everything. 