### PR TITLE
fix: update docs link

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -56,7 +56,7 @@ resources:
     upstream-source: nginx/nginx-prometheus-exporter:1.1.0
 
 links:
-  documentation: https://discourse.charmhub.io/t/tempo-coordinator-k8s-docs-index/15419
+  documentation: https://documentation.ubuntu.com/observability/latest/
   website: https://charmhub.io/tempo-coordinator-k8s
   source: https://github.com/canonical/tempo-operators
   issues: https://github.com/canonical/tempo-operators/issues

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -30,7 +30,7 @@ description: |
   - Configurable Kubernetes resource limits for CPU and memory.
 
 links:
-  documentation: https://discourse.charmhub.io/t/tempo-worker-k8s-index/15420
+  documentation: https://documentation.ubuntu.com/observability/latest/
   website: https://charmhub.io/tempo-worker-k8s
   source: https://github.com/canonical/tempo-operators
   issues: https://github.com/canonical/tempo-operators/issues


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The documentation field should point to the stack docs. Based on what I've seen, it looks like all the content in Discourse has already been moved to the stack docs.

## Solution
<!-- A summary of the solution addressing the above issue -->
Also moving an item from Discourse to the stack repo in this PR: https://github.com/canonical/observability-stack/pull/389

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed tempo, ... -->
