### PR TITLE
refactor: avoid hardcoding endpoints in the TF module (#324)

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -16,24 +16,24 @@ output "app_names" {
 
 output "provides" {
   value = {
-    tempo_cluster     = "tempo-cluster"
-    grafana_dashboard = "grafana-dashboard",
-    grafana_source    = "grafana-source",
-    metrics_endpoint  = "metrics-endpoint",
+    tempo_cluster     = module.tempo_coordinator.provides.tempo_cluster,
+    grafana_dashboard = module.tempo_coordinator.provides.grafana_dashboard,
+    grafana_source    = module.tempo_coordinator.provides.grafana_source,
+    metrics_endpoint  = module.tempo_coordinator.provides.metrics_endpoint,
     provide_cmr_mesh  = module.tempo_coordinator.provides.provide_cmr_mesh,
-    tracing           = "tracing",
+    tracing           = module.tempo_coordinator.provides.tracing,
   }
   description = "All Juju integration endpoints where the charm is the provider"
 }
 
 output "requires" {
   value = {
-    logging            = "logging",
-    ingress            = "ingress",
-    certificates       = "certificates",
-    send-remote-write  = "send-remote-write",
-    receive_datasource = "receive-datasource"
-    catalogue          = "catalogue",
+    logging            = module.tempo_coordinator.requires.logging,
+    ingress            = module.tempo_coordinator.requires.ingress,
+    certificates       = module.tempo_coordinator.requires.certificates,
+    send-remote-write  = module.tempo_coordinator.requires.send_remote_write,
+    receive_datasource = module.tempo_coordinator.requires.receive_datasource,
+    catalogue          = module.tempo_coordinator.requires.catalogue,
     require_cmr_mesh   = module.tempo_coordinator.requires.require_cmr_mesh,
     service_mesh       = module.tempo_coordinator.requires.service_mesh,
   }


### PR DESCRIPTION
## Issue

The top-level `terraform/outputs.tf` hardcodes the coordinator's integration
endpoint strings (e.g. `"tempo-cluster"`, `"grafana-dashboard"`, `"tracing"`),
duplicating values that the coordinator sub-module already exposes. If the
coordinator module ever renames an endpoint, the component module would silently
drift out of sync and could introduce bugs.

Closes #324

## Solution

Link the `provides`/`requires` entries in `terraform/outputs.tf` to the
coordinator sub-module's output surface (`module.tempo_coordinator.provides.*`
and `module.tempo_coordinator.requires.*`) instead of hardcoding the endpoint
strings. This follows the pattern already used by `provide_cmr_mesh`,
`require_cmr_mesh`, and `service_mesh`. The output keys are unchanged, so the
module's public interface is preserved.

## Context

The product module under `terraform/` composes the `coordinator/terraform` and
`worker/terraform` sub-modules. Each sub-module already exports its Juju
integration endpoints via `provides` and `requires` outputs, making them the
authoritative source. Referencing those outputs keeps the top-level module a
single source of truth rather than re-declaring the same endpoint names.

## Testing Instructions

- `terraform fmt -check` and `terraform validate` in `terraform/` pass.
- Run `terraform plan`; the `provides` and `requires` outputs resolve to the
  same endpoint values as before (no change in plan output for the outputs).

## Upgrade Notes

None. This is an internal refactor with no change to the output keys or their
resolved values; the module interface is unchanged.
