### PR TITLE
fix: correct invalid LogQL expression in tempo-operational dashboard

### DIFF
--- a/coordinator/src/grafana_dashboards/tempo-operational.json
+++ b/coordinator/src/grafana_dashboards/tempo-operational.json
@@ -24,7 +24,7 @@
           "uid": "$logsds"
         },
         "enable": true,
-        "expr": "{diff_{}container='kube-diff-logger'}",
+        "expr": "{cluster=\"$cluster\", diff_namespace=\"$namespace\", container=\"kube-diff-logger\"}",
         "hide": true,
         "iconColor": "rgba(255, 96, 96, 1)",
         "name": "diffs",


### PR DESCRIPTION
## Summary
- The "diffs" annotation query in the tempo-operational Grafana dashboard used an invalid LogQL expression (`diff_{}container='kube-diff-logger'`) with a malformed label name and single-quoted label value.
- Restores the expression to match the upstream Grafana tempo-mixin dashboard, using the `cluster` and `namespace` template variables already defined in this dashboard.

Fixes #272

## Test plan
- [x] Verified the updated `expr` field is valid JSON
- [x] Validated both the original (broken) and fixed expressions against a real Loki instance's LogQL parser:
  - Broken: `parse error at line 1, col 7: syntax error: unexpected {, expecting = or =~ or !~ or !=`
  - Fixed: parses and executes successfully
- [x] Confirmed the corrected expression matches the upstream Grafana tempo-mixin source and uses template variables (`$cluster`, `$namespace`) already defined in this dashboard