### PR TITLE
fix(charm-tracing): lower buffer overflow logs to dev_logger.debug

### DIFF
--- a/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -143,7 +143,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 
@@ -222,7 +222,7 @@ class _Buffer:
         overflow = len(queue) - self._max_event_history_length
         if overflow > 0:
             n_dropped_spans += overflow
-            logger.warning(
+            dev_logger.debug(
                 "charm tracing buffer exceeds max history length (%d events)",
                 self._max_event_history_length,
             )
@@ -239,7 +239,7 @@ class _Buffer:
 
             # only do this once
             if not logged_drop:
-                logger.warning(
+                dev_logger.debug(
                     "charm tracing buffer exceeds size limit (%dMiB).",
                     self._max_buffer_size_mib,
                 )

--- a/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -222,7 +222,7 @@ class _Buffer:
         overflow = len(queue) - self._max_event_history_length
         if overflow > 0:
             n_dropped_spans += overflow
-            dev_logger.debug(
+            logger.debug(
                 "charm tracing buffer exceeds max history length (%d events)",
                 self._max_event_history_length,
             )
@@ -239,7 +239,7 @@ class _Buffer:
 
             # only do this once
             if not logged_drop:
-                dev_logger.debug(
+                logger.debug(
                     "charm tracing buffer exceeds size limit (%dMiB).",
                     self._max_buffer_size_mib,
                 )


### PR DESCRIPTION
## Issue

Fixes #257

The charm tracing buffer logs a `WARNING` every time it prunes spans past the max history length or the buffer size limit. These overflows are routine and the warnings are noisy.

As discussed in the issue, this lowers both messages to `dev_logger.debug` — matching the pattern already used elsewhere in `_prune` (e.g. the `n_dropped_spans` summary, and the buffer-disabled message in `save`).

## Changes

- `_prune`: `logger.warning(...)` → `dev_logger.debug(...)` for the "exceeds max history length" message.
- `_prune`: `logger.warning(...)` → `dev_logger.debug(...)` for the "exceeds size limit" message.
- Bump `LIBPATCH` 13 → 14 (required for any charm lib change).

Kept intentionally minimal — no migration to `ops[tracing]`, just the log-level fix requested.
