### PR TITLE
fix(charm_tracing): use public API for Python version compatibility

### DIFF
--- a/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -30,18 +30,23 @@ def _remove_stale_otel_sdk_packages():
         return
 
     import logging
+    import re
     import shutil
     from collections import defaultdict
 
     from importlib.metadata import distributions
+
+    def _normalize_name(name: str) -> str:
+        """Normalize package name per PEP 503."""
+        return re.sub(r"[-_.]+", "-", name).lower()
 
     otel_logger = logging.getLogger("charm_tracing_otel_patcher")
     otel_logger.debug("Applying _remove_stale_otel_sdk_packages patch on charm upgrade")
     # group by name all distributions starting with "opentelemetry_"
     otel_distributions = defaultdict(list)
     for distribution in distributions():
-        name = distribution._normalized_name  # type: ignore
-        if name.startswith("opentelemetry_"):
+        name = _normalize_name(distribution.name)
+        if name.startswith("opentelemetry-"):
             otel_distributions[name].append(distribution)
 
     otel_logger.debug("Found %d opentelemetry distributions", len(otel_distributions))
@@ -56,7 +61,9 @@ def _remove_stale_otel_sdk_packages():
         )
         for distribution in distributions_:
             if not distribution.files:  # Not None or empty list
-                path = distribution._path  # type: ignore
+                path = getattr(distribution, "_path", None)
+                if path is None:
+                    continue
                 otel_logger.info("Removing empty distribution of %s at %s.", name, path)
                 shutil.rmtree(path)
 
@@ -143,7 +150,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/coordinator/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -37,8 +37,8 @@ def _remove_stale_otel_sdk_packages():
     from importlib.metadata import distributions
 
     def _normalize_name(name: str) -> str:
-        """Normalize package name per PEP 503."""
-        return re.sub(r"[-_.]+", "-", name).lower()
+        """Normalize package name to underscore format (matching importlib_metadata behavior)."""
+        return re.sub(r"[-_.]+", "_", name).lower()
 
     otel_logger = logging.getLogger("charm_tracing_otel_patcher")
     otel_logger.debug("Applying _remove_stale_otel_sdk_packages patch on charm upgrade")
@@ -46,7 +46,7 @@ def _remove_stale_otel_sdk_packages():
     otel_distributions = defaultdict(list)
     for distribution in distributions():
         name = _normalize_name(distribution.name)
-        if name.startswith("opentelemetry-"):
+        if name.startswith("opentelemetry_"):
             otel_distributions[name].append(distribution)
 
     otel_logger.debug("Found %d opentelemetry distributions", len(otel_distributions))

--- a/coordinator/tests/unit/test_charm_tracing_compat.py
+++ b/coordinator/tests/unit/test_charm_tracing_compat.py
@@ -1,0 +1,58 @@
+"""Tests for charm_tracing library compatibility across Python versions."""
+
+import re
+from importlib.metadata import distributions
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize package name to underscore format (matching importlib_metadata behavior).
+
+    This is a copy of the function used in charm_tracing.py for testing purposes.
+    """
+    return re.sub(r"[-_.]+", "_", name).lower()
+
+
+def test_distribution_name_is_accessible():
+    """Verify that distribution.name is accessible for all installed distributions.
+
+    This tests the fix for https://github.com/canonical/tempo-operators/issues/355
+    where accessing distribution._normalized_name failed on Python 3.12 because
+    the stdlib importlib.metadata doesn't expose this private attribute.
+
+    The fix uses the public distribution.name API instead.
+    """
+    for distribution in distributions():
+        # This should not raise AttributeError
+        name = distribution.name
+        assert isinstance(name, str)
+        assert len(name) > 0
+
+
+def test_normalize_name_underscore_format():
+    """Test name normalization matches importlib_metadata._normalized_name behavior.
+
+    The original code used distribution._normalized_name which normalizes to underscores.
+    We replicate this behavior using distribution.name + manual normalization.
+    """
+    # All separators (hyphens, underscores, dots) should become underscores
+    assert _normalize_name("opentelemetry_sdk") == "opentelemetry_sdk"
+    assert _normalize_name("opentelemetry-sdk") == "opentelemetry_sdk"
+    assert _normalize_name("opentelemetry.sdk") == "opentelemetry_sdk"
+    assert _normalize_name("OpenTelemetry_SDK") == "opentelemetry_sdk"
+    # Multiple consecutive separators should collapse to single underscore
+    assert _normalize_name("OpenTelemetry__SDK") == "opentelemetry_sdk"
+    assert _normalize_name("opentelemetry---sdk") == "opentelemetry_sdk"
+    assert _normalize_name("opentelemetry_..sdk") == "opentelemetry_sdk"
+
+
+def test_opentelemetry_distributions_can_be_normalized():
+    """Verify opentelemetry packages can be found using the normalization logic."""
+    otel_distributions = []
+    for distribution in distributions():
+        name = _normalize_name(distribution.name)
+        if name.startswith("opentelemetry_"):
+            otel_distributions.append(name)
+
+    # We should find at least one opentelemetry package in the test environment
+    # since the charm depends on opentelemetry-exporter-otlp-proto-http
+    assert len(otel_distributions) > 0, "Expected to find opentelemetry distributions"


### PR DESCRIPTION
## Summary

Fix `charm_tracing` library failing on Python 3.12 (Ubuntu 24.04) during upgrade-charm events. The 26.04 bump changed the import from `importlib_metadata` (backport) to `importlib.metadata` (stdlib), but the code still accessed private attributes that don't exist in the stdlib version on Python 3.12.

## Changes

- Replace `distribution._normalized_name` with `distribution.name` + PEP 503 normalization
- Replace `distribution._path` with `getattr()` fallback to handle missing attribute
- Bump LIBPATCH from 13 to 14

Closes #355