### PR TITLE
chore: bump coordinated workers

### DIFF
--- a/coordinator/pyproject.toml
+++ b/coordinator/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.1"  # this is in fact irrelevant
 requires-python = "~=3.14.0"
 
 dependencies = [
-    "coordinated-workers>=4.0.0",
+    "coordinated-workers>=4.1.0",
     "pydantic<3",
     # ---PYDEPS---,
     # lib/charms/tls_certificates_interface/v4/tls_certificates.py

--- a/coordinator/uv.lock
+++ b/coordinator/uv.lock
@@ -136,15 +136,15 @@ wheels = [
 
 [[package]]
 name = "charmlibs-nginx-k8s"
-version = "0.1.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crossplane" },
     { name = "ops" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/1aacb27aa6b8cce0dbb30bba56e79336683ac981682bb761edab1d378f78/charmlibs_nginx_k8s-0.1.0.tar.gz", hash = "sha256:6e1486289546d5ee8f108aae01e886728c27aa556e1a18d0a57ab84aab4e4ab1", size = 36645, upload-time = "2025-12-15T09:38:22.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/64/4712bd0fbeda002361ef7b5e74bbf695004a29d6f3957d436ab06648b15f/charmlibs_nginx_k8s-1.0.1.tar.gz", hash = "sha256:9dcfeb52b9dbee77d66ab90ee86117d7494889325a2961fc7c55109b3d8dbbe9", size = 38679, upload-time = "2026-06-22T15:23:12.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/51/eb217b37f1907a19768abaf65b598a0ac2cceb12dcca087c09c7fbd716c8/charmlibs_nginx_k8s-0.1.0-py3-none-any.whl", hash = "sha256:3ea564cf2ca052234ba75578060af4c2246d6cf0f4936dfe767f19f922bc289d", size = 17348, upload-time = "2025-12-15T09:38:20.946Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1c/ef9ff46a5cb167ec917a86cfbdcb7bc2a98a8a767efa672bc30920b78dc6/charmlibs_nginx_k8s-1.0.1-py3-none-any.whl", hash = "sha256:8e5246e26aaa6ac749f8cd82db5a1dd30535612961afc7597c75933122c02638", size = 18177, upload-time = "2026-06-22T15:23:11.52Z" },
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "coordinated-workers"
-version = "4.0.1"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charmed-service-mesh-helpers" },
@@ -224,9 +224,9 @@ dependencies = [
     { name = "ops", extra = ["tracing"] },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/d0/6b6921e1fbb1e1a1539c37308683c6c1dea110419d3de45a945f3a7549c4/coordinated_workers-4.0.1.tar.gz", hash = "sha256:dc19d73285b6164e909bfad528ef18e5542fe0d092395101cc19189d6160b2fc", size = 379113, upload-time = "2026-04-30T16:11:40.949Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/0f/4eb6682434382c734bf70821efacbb48932e5b847227669d89fe7e4a2bb9/coordinated_workers-4.1.0.tar.gz", hash = "sha256:5218b4aa0dc78a3b3abaaab9bcb35adc4140efdaf92f06fb0fcaf10eaa707125", size = 380170, upload-time = "2026-06-23T15:11:59.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/3e/5ed2f4a4b9abb995d49a03bee9eca92263240edddf4ec5554ca8a2bc0721/coordinated_workers-4.0.1-py3-none-any.whl", hash = "sha256:9f753274a65a31874ea2c4ece7fd547209406aafed5f8748ab96f197d751c03d", size = 48498, upload-time = "2026-04-30T16:11:39.215Z" },
+    { url = "https://files.pythonhosted.org/packages/31/24/7826b9d84b1e5b7d2eeb4381cc0d1c3e7163fdf93efde559997fa2bfa17b/coordinated_workers-4.1.0-py3-none-any.whl", hash = "sha256:4e4779017f33dfdef647302dd10a106893c7c7a04941bf7cb934a8495dd43279", size = 48530, upload-time = "2026-06-23T15:11:58.21Z" },
 ]
 
 [[package]]
@@ -963,7 +963,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "charmed-service-mesh-helpers", specifier = ">=0.2.0" },
-    { name = "coordinated-workers", specifier = ">=4.0.0" },
+    { name = "coordinated-workers", specifier = ">=4.1.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "cryptography" },
     { name = "jubilant", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Related to and fixes https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/278. 
Similar to:
- https://github.com/canonical/loki-operators/pull/114
- https://github.com/canonical/mimir-operators/pull/110
## Solution
<!-- A summary of the solution addressing the above issue -->
Fetches the latest updates in: Related to: https://github.com/canonical/charmlibs/pull/539.

This change is needed fix the self-monitoring issue when Tempo's Nginx metrics are being scraped and when internal TLS is enabled.

To see the original issue, deploy the following bundle:
```yaml
bundle: kubernetes

applications:
  otelcol:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 188
    resources:
      opentelemetry-collector-image: 9
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true

  ssc:
    charm: self-signed-certificates
    channel: 1/stable
    revision: 588
    base: ubuntu@22.04/stable
    scale: 1
    constraints: arch=amd64

  swfs-t:
    charm: seaweedfs-k8s
    channel: latest/edge
    revision: 9
    resources:
      seaweedfs-image: 2
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true

  tempo:
    charm: tempo-coordinator-k8s
    channel: dev/edge
    revision: 155
    base: ubuntu@26.04/stable
    resources:
      nginx-image: 9
      nginx-prometheus-exporter-image: 5
    scale: 1
    constraints: arch=amd64
    trust: true

  tempo-worker:
    charm: tempo-worker-k8s
    channel: dev/edge
    revision: 110
    base: ubuntu@26.04/stable
    resources:
      tempo-image: 14
    scale: 1
    options:
      role-all: true
    constraints: arch=amd64
    storage:
      wal: kubernetes,1,1024M
    trust: true

  trfk:
    charm: traefik-k8s
    channel: latest/edge
    revision: 324
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 167
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true

relations:
  - - tempo:tempo-cluster
    - tempo-worker:tempo-cluster

  - - tempo:s3
    - swfs-t:s3-credentials

  - - otelcol:send-traces
    - tempo:tracing

  - - otelcol:metrics-endpoint
    - tempo:metrics-endpoint

  - - tempo:certificates
    - ssc:certificates
```

If you look at the Otelcol config, you'll see the following block under the receivers:
```bash
...
scheme: https
        scrape_interval: 1m
        scrape_timeout: 10s
        static_configs:
        - labels:
            juju_application: tempo
            juju_charm: tempo-coordinator-k8s
            juju_model: test
            juju_model_uuid: c7be444e-e91c-4761-8d02-9877f258ed86
            juju_unit: tempo/0
          targets:
          - tempo-0.tempo-endpoints.test.svc.cluster.local:9113
...
```

However, Otelcol fails to scrape that address because Tempo's Nginx is not listening to HTTPS request, even though it should.
```bash
curl https://tempo-0.tempo-endpoints.test.svc.cluster.local:9113/metrics
curl: (35) OpenSSL/3.0.13: error:0A00010B:SSL routines::wrong version number
```
## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Pack the coordinator charm with changes from this branch and refresh Tempo.
## Internal TLS, no ingress
Now, from inside the `otelcol` container, you should be able to hit the Pexp metrics endpoint and get a 200 (using HTTPS).
```bash
curl https://tempo-0.tempo-endpoints.test.svc.cluster.local:9113/metrics
```
## Internal TSL, with ingress
We should get a 405 when we hit the tracing endpoint.
```bash
curl http://10.181.160.41:4318/v1/traces
```
The Pexp endpoint should still use HTTPS and the FQDN of `tempo-0.tempo-endpoints.test.svc.cluster.local:9113`, but that's due to https://github.com/canonical/cos-coordinated-workers/issues/168.

The other scenarios work as well, but they're out of scope for this PR anyway, so no need to include them.
## Upgrade Notes
<!-- To upgrade from an older revision of charmed tempo, ... -->
