### PR TITLE
fix: Deploy Grafana from a real revision

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -293,7 +293,7 @@ def deploy_grafana(juju: Juju):
     juju.deploy(
         "grafana-k8s",
         app=GRAFANA_APP,
-        revision=187,  # what's on dev/edge at May 26, 2026.
+        revision=190,  # what's on dev/edge at May 26, 2026.
         channel=DEV_EDGE_CHANNEL,
         trust=True,
     )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
CI is failing itests:
- https://github.com/canonical/tempo-operators/actions/runs/28437029786/job/84313230778?pr=364#step:6:97

this is due to:
```
❯ juju deploy grafana-k8s grafana --channel dev/edge --revision 187 --trust    
ERROR listing resources for charm "ch:amd64/grafana-k8s-187": No revision was found in the Store.
ERROR failed to deploy charm "grafana-k8s"

❯ juju deploy grafana-k8s grafana --channel dev/edge --trust                                   
Deployed "grafana" from charm-hub charm "grafana-k8s", revision 190 in channel dev/edge on ubuntu@26.04/stable
```

## Solution
<!-- A summary of the solution addressing the above issue -->
Bumps the revision, although we should ask ourselves what happened to the `rev187` release?

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed tempo, ... -->
