### PR TITLE
feat: add support for local-blocks processor

### DIFF
--- a/coordinator/src/tempo.py
+++ b/coordinator/src/tempo.py
@@ -149,6 +149,7 @@ class Tempo:
                     processors=[
                         tempo_config.MetricsGeneratorProcessorLabel.SPAN_METRICS,
                         tempo_config.MetricsGeneratorProcessorLabel.SERVICE_GRAPHS,
+                        tempo_config.MetricsGeneratorProcessorLabel.LOCAL_BLOCKS,
                     ],
                 )
             )
@@ -185,8 +186,11 @@ class Tempo:
             processor=tempo_config.MetricsGeneratorProcessor(
                 span_metrics=tempo_config.MetricsGeneratorSpanMetricsProcessor(),
                 service_graphs=tempo_config.MetricsGeneratorServiceGraphsProcessor(),
+                # TODO: This is Tempo 2.x configuration. When Tempo 3.x support is added, switch this to the live-store processor/path.
+                local_blocks=tempo_config.MetricsGeneratorLocalBlocksProcessor(
+                    filter_server_spans=False,
+                ),
             ),
-            # per-processor configuration should go in here
         )
         return config
 

--- a/coordinator/src/tempo.py
+++ b/coordinator/src/tempo.py
@@ -28,6 +28,7 @@ class Tempo:
 
     wal_path = "/etc/tempo/tempo_wal"
     metrics_generator_wal_path = "/etc/tempo/metrics_generator_wal"
+    metrics_generator_traces_path = "/etc/tempo/generator_traces"
 
     # this is the single source of truth for which ports are opened and configured
     # in the distributed Tempo deployment
@@ -180,6 +181,9 @@ class Tempo:
             storage=tempo_config.MetricsGeneratorStorage(
                 path=self.metrics_generator_wal_path,
                 remote_write=remote_write_instances,
+            ),
+            traces_storage=tempo_config.MetricsGeneratorTracesStorage(
+                path=self.metrics_generator_traces_path,
             ),
             # Adding juju topology will be done on the worker's side
             # to populate the correct unit label.

--- a/coordinator/src/tempo_config.py
+++ b/coordinator/src/tempo_config.py
@@ -343,13 +343,21 @@ class MetricsGeneratorServiceGraphsProcessor(BaseModel):
     # for a full list of config options
 
 
+class MetricsGeneratorLocalBlocksProcessor(BaseModel):
+    """Metrics Generator local_blocks processor configuration schema."""
+
+    filter_server_spans: bool = False
+    # see https://grafana.com/docs/tempo/v2.6.x/configuration/#metrics-generator
+    # and https://grafana.com/docs/tempo/v2.6.x/operations/traceql-metrics/#activate-and-configure-the-local-blocks-processor
+    # for a full list of config options
+
+
 class MetricsGeneratorProcessor(BaseModel):
     """Metrics Generator processor schema."""
 
     span_metrics: MetricsGeneratorSpanMetricsProcessor
     service_graphs: MetricsGeneratorServiceGraphsProcessor
-    # see https://grafana.com/docs/tempo/v2.6.x/configuration/#metrics-generator
-    # for a full list of config options; could add local_blocks here
+    local_blocks: MetricsGeneratorLocalBlocksProcessor
 
 
 class MetricsGeneratorStorage(BaseModel):

--- a/coordinator/src/tempo_config.py
+++ b/coordinator/src/tempo_config.py
@@ -352,6 +352,18 @@ class MetricsGeneratorLocalBlocksProcessor(BaseModel):
     # for a full list of config options
 
 
+class MetricsGeneratorTracesStorage(BaseModel):
+    """Metrics Generator traces_storage configuration schema.
+
+    Required in Tempo >= 2.10 for the local_blocks processor. Provides the
+    path where the metrics-generator stores its own trace WAL, independently
+    of the ingester WAL.
+    See https://grafana.com/docs/tempo/latest/configuration/#metrics-generator
+    """
+
+    path: str
+
+
 class MetricsGeneratorProcessor(BaseModel):
     """Metrics Generator processor schema."""
 
@@ -372,6 +384,7 @@ class MetricsGenerator(BaseModel):
 
     ring: Ring
     storage: MetricsGeneratorStorage
+    traces_storage: MetricsGeneratorTracesStorage
 
     # processor-specific config depends on the processor type
     processor: MetricsGeneratorProcessor

--- a/coordinator/tests/unit/test_config.py
+++ b/coordinator/tests/unit/test_config.py
@@ -82,4 +82,12 @@ def test_metrics_generator(
         assert config["metrics_generator"]["storage"]["remote_write"] == [
             json.loads(remote_write.remote_units_data[0]["remote_write"])
         ]
+        assert config["metrics_generator"]["processor"]["local_blocks"] == {
+            "filter_server_spans": False
+        }
         assert "overrides" in config
+        assert config["overrides"]["defaults"]["metrics_generator"]["processors"] == [
+            "span-metrics",
+            "service-graphs",
+            "local-blocks",
+        ]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -636,3 +636,33 @@ def service_mesh(
             delay=5,
             successes=5,
         )
+
+
+def scrape_metrics(juju: Juju, app: str) -> str:
+    """Scrape the Prometheus /metrics endpoint of *app* and return the raw text."""
+    app_ip = get_app_ip_address(juju, app)
+    resp = requests.get(f"http://{app_ip}:3200/metrics", timeout=15)
+    resp.raise_for_status()
+    return resp.text
+
+
+def metric_value(metrics_text: str, metric_name: str) -> float:
+    """Return the sum of all label combinations for *metric_name*.
+
+    Raises ``KeyError`` if the metric is not present at all.
+    """
+    total = 0.0
+    found = False
+    for line in metrics_text.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        bare = line.split("{")[0].split()[0]
+        if bare == metric_name:
+            try:
+                total += float(line.split()[-1])
+                found = True
+            except ValueError:
+                pass
+    if not found:
+        raise KeyError(f"metric not found: {metric_name!r}")
+    return total

--- a/tests/integration/test_local_blocks_processor.py
+++ b/tests/integration/test_local_blocks_processor.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Integration tests for the local_blocks metrics-generator processor (PR #418)."""
+
+import logging
+
+import jubilant
+import pytest
+from jubilant import Juju
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+from tests.integration.helpers import (
+    PROMETHEUS_APP,
+    S3_APP,
+    TEMPO_APP,
+    WORKER_APP,
+    deploy_monolithic_cluster,
+    deploy_prometheus,
+    metric_value,
+    scrape_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.juju_setup
+def test_deploy(juju: Juju):
+    """Deploy a monolithic cluster with remote-write to enable the metrics-generator."""
+    deploy_monolithic_cluster(juju, wait_for_idle=False)
+    deploy_prometheus(juju)
+    juju.integrate(
+        f"{PROMETHEUS_APP}:receive-remote-write",
+        f"{TEMPO_APP}:send-remote-write",
+    )
+    juju.wait(
+        lambda status: jubilant.all_active(
+            status, TEMPO_APP, WORKER_APP, S3_APP, PROMETHEUS_APP
+        ),
+        timeout=2000,
+        delay=5,
+        successes=3,
+    )
+
+
+def test_local_blocks_processor_active(juju: Juju):
+    # local_blocks_spans_total is only emitted when the processor exists in
+    # the processor config and in the overrides list (both added by PR #418).
+    metrics = scrape_metrics(juju, WORKER_APP)
+    spans = metric_value(metrics, "tempo_metrics_generator_processor_local_blocks_spans_total")
+    assert spans > 0
+
+
+def test_local_blocks_wal_operational(juju: Juju):
+    # live_trace_bytes > 0 proves traces_storage.path is set and the WAL head
+    # block is accepting writes. Retry covers the brief window between a flush
+    # and the next incoming span.
+    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10))
+    def _check() -> None:
+        metrics = scrape_metrics(juju, WORKER_APP)
+        live_bytes = metric_value(
+            metrics,
+            "tempo_metrics_generator_processor_local_blocks_live_trace_bytes",
+        )
+        assert live_bytes > 0
+
+    _check()
+
+
+def test_local_blocks_no_flush_errors(juju: Juju):
+    metrics = scrape_metrics(juju, WORKER_APP)
+    failed = metric_value(
+        metrics, "tempo_metrics_generator_processor_local_blocks_failed_flushes_total"
+    )
+    assert failed == 0
+
+
+@pytest.mark.juju_teardown
+def test_teardown(juju: Juju):
+    for app in (WORKER_APP, TEMPO_APP, S3_APP, PROMETHEUS_APP):
+        if app in juju.status().apps:
+            juju.remove_application(app)

--- a/tests/integration/test_local_blocks_processor.py
+++ b/tests/integration/test_local_blocks_processor.py
@@ -40,20 +40,25 @@ def test_deploy(juju: Juju):
         delay=5,
         successes=3,
     )
+    # speed up update-status hooks to generate self-traces faster
+    juju.cli("model-config", "update-status-hook-interval=10s")
 
 
 def test_local_blocks_processor_active(juju: Juju):
-    # local_blocks_spans_total is only emitted when the processor exists in
-    # the processor config and in the overrides list (both added by PR #418).
-    metrics = scrape_metrics(juju, WORKER_APP)
-    spans = metric_value(metrics, "tempo_metrics_generator_processor_local_blocks_spans_total")
-    assert spans > 0
+    # retry: metrics-generator pipeline is async
+    @retry(stop=stop_after_attempt(12), wait=wait_fixed(10))
+    def _check() -> None:
+        metrics = scrape_metrics(juju, WORKER_APP)
+        spans = metric_value(
+            metrics, "tempo_metrics_generator_processor_local_blocks_spans_total"
+        )
+        assert spans > 0
+
+    _check()
 
 
 def test_local_blocks_wal_operational(juju: Juju):
-    # live_trace_bytes > 0 proves traces_storage.path is set and the WAL head
-    # block is accepting writes. Retry covers the brief window between a flush
-    # and the next incoming span.
+    # live_trace_bytes > 0 proves traces_storage.path is set
     @retry(stop=stop_after_attempt(6), wait=wait_fixed(10))
     def _check() -> None:
         metrics = scrape_metrics(juju, WORKER_APP)


### PR DESCRIPTION
## Issue
Fixes #328 which causes a warning to pop-up in Grafana.

## Solution
Add local-blocks processor to the config.

## Context
Avoided setting [flush_to_storage](https://archive.grafana.com/docs/tempo/v2.6.x/operations/traceql-metrics/#activate-and-configure-the-local-blocks-processor:~:text=Setting%20flush_to_storage%20to%20true%20ensures%20that%20metrics%20blocks%20are%20flushed%20to%20storage%20so%20TraceQL%20metrics%20queries%20against%20historical%20data.) which would push more blocks to storage but also enable longer term queries. IIRC it's limited to 30 mins or so with the current setting? Can be added on if needed.


## Testing Instructions
Spin up cos-lite w/ tempo charms, check in the Grafana


